### PR TITLE
More robust usage of localStorage which could be unavailable or disabled

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -7,10 +7,11 @@
 "ep_bookmark.cancel": "Abbrechen",
 "ep_bookmark.editIcon.title": "Bearbeite den Kommentar für dieses Lesezeichen",
 "ep_bookmark.saveIcon.title": "Speichere den Kommentar für dieses Lesezeichen",
-"ep_bookmark.closeIcon.title": "Breche das Editieren des Kommentares ab",
+"ep_bookmark.closeIcon.title": "Breche das Editieren des Kommentars ab",
 "ep_bookmark.deleteIcon.title": "Lösche dieses Lesezeichen",
 "ep_bookmark.autoAdded": "automatisch hinzugefügt",
 "ep_bookmark.lastVisit": "Letzter Besuch",
 "ep_bookmark.info": "Info",
-"ep_bookmark.info.title": "Hier können Lesezeichen der Pads dieses Servers gespeichert werden. Diese werden nur in diesem Browser gespeichert. Die Anzeige der Pads ist sortiert nach dem zuletzt Besuchten"
+"ep_bookmark.info.title": "Hier können Lesezeichen der Pads dieses Servers gespeichert werden. Diese werden nur in diesem Browser gespeichert. Die Anzeige der Pads ist sortiert nach dem letzten Besuch.",
+"ep_bookmark.notSupported": "Dein Browser unterstützt das Speichern von Lesezeichen nicht."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,5 +12,6 @@
 "ep_bookmark.autoAdded": "automatically added",
 "ep_bookmark.lastVisit": "Last visit",
 "ep_bookmark.info": "Info",
-"ep_bookmark.info.title": "Here you can save a list of your pads on this server. The list is only stored in your browser and is ordered beginning with the latest visited pad."
+"ep_bookmark.info.title": "Here you can save a list of your pads on this server. The list is only stored in your browser and is ordered beginning with the latest visited pad.",
+"ep_bookmark.notSupported": "Your browser does not support saving of bookmarks."
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -2,51 +2,46 @@
  * Refreshs the overlay for the pad bookmark list and its content
  */
 var refreshPadList = function() {
-  $("#padBookmarkList").empty();
+  var bookmarks = bookmarkStorage.getAllPadBookmarks();
+  var padDiv;
+  var padLinkTag;
+  var commentTag;
+  var commentEditTag;
+  var editTag;
+  var saveTag;
+  var closeTag;
   
-  if (bookmarkStorage.supported()) {
-    var bookmarks = bookmarkStorage.getAllPadBookmarks();
-    var padDiv;
-    var padLinkTag;
-    var commentTag;
-    var commentEditTag;
-    var editTag;
-    var saveTag;
-    var closeTag;
-    
-    if (bookmarks.length == 0) {
-      $("#padBookmarkList").append("<div id='noPads'></div>").text(html10n.get("ep_bookmark.noPads"));
-    } else {
-      for (var i=0; i < bookmarks.length; i++) {
-        padDiv = $("<div/>").attr('class', 'padBookmark').attr('id', bookmarks[i].padId);
-        padLinkTag = $("<a class='bookmarkPadId' href='javascript:pad.switchToPad(\""+bookmarks[i].padId+"\")'>"+bookmarks[i].padId+"</a>").attr('title', html10n.get("ep_bookmark.lastVisit")+': '+new Date(bookmarks[i].timestamp).toLocaleString());
-        commentTag = $("<span/>").attr('class', 'comment').text(bookmarks[i].description);
-        commentEditTag = $("<input/>").attr('class', 'editComment');
-        editTag = $("<a class='editIcon' href='#'>&#9997;</a>'").click(editCommentClick);
-        saveTag = $("<a class='saveIcon' href='#'>&#10003;</a>'").click(saveCommentClick);
-        closeTag = $("<a class='closeIcon' href='#'>&#10007;</a>'").click(closeCommentClick);
-        deleteTag = $("<a class='deleteIcon' href='#'>&#10006;</a>").click(removePadClick);
-        
-        padDiv.append(padLinkTag).append(" ").append(commentTag).append(commentEditTag).append(" ").append(editTag).append(saveTag).append(closeTag).append(deleteTag);
-        $("#padBookmarkList").append(padDiv);
-      }
-      $(".editIcon").attr('title', (html10n.get("ep_bookmark.editIcon.title")));
-      $(".saveIcon").attr('title', (html10n.get("ep_bookmark.saveIcon.title")));
-      $(".closeIcon").attr('title', (html10n.get("ep_bookmark.closeIcon.title")));
-      $(".deleteIcon").attr('title', (html10n.get("ep_bookmark.deleteIcon.title")));
-      
-      $(".editComment").keyup(function(e){
-        // ESC pressed
-        if (e.keyCode == 27){
-          abortCommentEditing($(e.currentTarget).parent());
-        // Enter pressed
-        } else if (e.keyCode == 13) {
-          saveComment($(e.currentTarget).parent());
-        }
-      });
-    }
+  $("#padBookmarkList").empty();
+  if (bookmarks.length == 0) {
+    $("#padBookmarkList").append("<div id='noPads'></div>").text(html10n.get("ep_bookmark.noPads"));
   } else {
-    $("#padBookmarkList").text("Not supported");
+    for (var i=0; i < bookmarks.length; i++) {
+      padDiv = $("<div/>").attr('class', 'padBookmark').attr('id', bookmarks[i].padId);
+      padLinkTag = $("<a class='bookmarkPadId' href='javascript:pad.switchToPad(\""+bookmarks[i].padId+"\")'>"+bookmarks[i].padId+"</a>").attr('title', html10n.get("ep_bookmark.lastVisit")+': '+new Date(bookmarks[i].timestamp).toLocaleString());
+      commentTag = $("<span/>").attr('class', 'comment').text(bookmarks[i].description);
+      commentEditTag = $("<input/>").attr('class', 'editComment');
+      editTag = $("<a class='editIcon' href='#'>&#9997;</a>'").click(editCommentClick);
+      saveTag = $("<a class='saveIcon' href='#'>&#10003;</a>'").click(saveCommentClick);
+      closeTag = $("<a class='closeIcon' href='#'>&#10007;</a>'").click(closeCommentClick);
+      deleteTag = $("<a class='deleteIcon' href='#'>&#10006;</a>").click(removePadClick);
+        
+      padDiv.append(padLinkTag).append(" ").append(commentTag).append(commentEditTag).append(" ").append(editTag).append(saveTag).append(closeTag).append(deleteTag);
+      $("#padBookmarkList").append(padDiv);
+    }
+    $(".editIcon").attr('title', (html10n.get("ep_bookmark.editIcon.title")));
+    $(".saveIcon").attr('title', (html10n.get("ep_bookmark.saveIcon.title")));
+    $(".closeIcon").attr('title', (html10n.get("ep_bookmark.closeIcon.title")));
+    $(".deleteIcon").attr('title', (html10n.get("ep_bookmark.deleteIcon.title")));
+    
+    $(".editComment").keyup(function(e){
+      // ESC pressed
+      if (e.keyCode == 27){
+        abortCommentEditing($(e.currentTarget).parent());
+        // Enter pressed
+      } else if (e.keyCode == 13) {
+        saveComment($(e.currentTarget).parent());
+      }
+    });
   }
 }
 
@@ -90,10 +85,22 @@ var refreshPadList = function() {
 *********/
 var bookmarkStorage = {
   supported: function() {
-    return typeof(Storage) !== "undefined";
+    var mod = 'padBookmarksTest';
+    try {
+      localStorage.setItem(mod, mod);
+      localStorage.removeItem(mod);
+      return true;
+    } catch(e) {
+      return false;
+    }
   },
   getLocalStorageItem: function() {
-    var item = localStorage.getItem("padBookmarks");
+    var item = null;
+    try {
+      item = localStorage.getItem("padBookmarks");
+    } catch (e) {
+      
+    }
     if (item == null) {
       item = {"options": {}, "padList": []};
     } else {
@@ -149,7 +156,11 @@ var bookmarkStorage = {
     return bookmarkStorage.getPadBookmark(padId) == null ? false : true;
   },
   saveLocalStorageItem: function(storageItem) {
-    localStorage.setItem("padBookmarks", JSON.stringify(storageItem));
+    try {
+      localStorage.setItem("padBookmarks", JSON.stringify(storageItem));
+    } catch (e) {
+    
+    }
   },
   addPad: function(padId, desc) {
     if (!bookmarkStorage.padBookmarkExists(padId)) {
@@ -308,16 +319,24 @@ var documentReady = function (hook, context) {
     if (module.css('display') == "none") {
       $("#addPadBookmark").val(html10n.get("ep_bookmark.addPadToBookmarks"));
       $("#infoText").attr("title", html10n.get("ep_bookmark.info.title"));
+      $("#addBookmarksAutomatically").attr('title', html10n.get("ep_bookmark.addBookmarksAutomatically.title"));
+      $("#managePadBookmarks").attr('title', html10n.get("ep_bookmark.bookmarkTitle"));
+      
+      if (bookmarkStorage.supported()) {
+        $("#padBookmarkMain").show();
+        $("#padBookmarkError").hide();
+        $("#autoAddBookmarkCheckbox").attr('checked', bookmarkStorage.getOption("addBookmarksAutomatically"));
+        $("#addPadBookmark").attr('disabled', $("#autoAddBookmarkCheckbox").attr('checked'));
+        refreshPadList();
+      } else {
+        $("#padBookmarkMain").hide();
+        $("#padBookmarkError").show();
+      }
     }
-    
-    refreshPadList();
   });
-  
-  $("#autoAddBookmarkCheckbox").attr('checked', bookmarkStorage.getOption("addBookmarksAutomatically"));
 
-  $("#addPadBookmark").attr('disabled', $("#autoAddBookmarkCheckbox").attr('checked'))
-    .click(function() {
-      bookmarkStorage.addPad(pad.getPadId());
+  $("#addPadBookmark").click(function() {
+    bookmarkStorage.addPad(pad.getPadId());
   });
   
   $("#autoAddBookmarkCheckbox").change(function() {
@@ -329,10 +348,6 @@ var documentReady = function (hook, context) {
 var postAceInit = function(hook, context) {
   updateLastVisitTime();
   autoAddBookmark();
-  
-  $("#addBookmarksAutomatically").attr('title', html10n.get("ep_bookmark.addBookmarksAutomatically.title"));
-  
-  $("#managePadBookmarks").attr('title', html10n.get("ep_bookmark.bookmarkTitle"));
 }
 
 var postToolbarInit = function(hook, context) {

--- a/templates/modals.ejs
+++ b/templates/modals.ejs
@@ -3,17 +3,21 @@
         <h1 data-l10n-id="ep_bookmark.bookmarkTitle">Manage your pad bookmarks</h1>
         <a href="https://github.com/Gared/ep_bookmark/wiki" target="_blank" id="infoText" data-l10n-id="ep_bookmark.info">Info</a>
         
-        <div id="padBookmarkList">
+        <span id="padBookmarkError" data-l10n-id="ep_bookmark.notSupported">Your browser does not support saving of bookmarks.</span>
         
-        </div>
-        <br/>
-        <div>
-            <input id="autoAddBookmarkCheckbox" type="checkbox"/>
-            <span id="addBookmarksAutomatically" data-l10n-id="ep_bookmark.addBookmarksAutomatically">Add bookmarks automatically</span>
-        </div>
-        <br/>
-        <div>
-            <input type="button" class="embedMediaButton" id="addPadBookmark" data-l10n-id="ep_bookmark.addPadToBookmarks" value="Add this pad to bookmarks">
+        <div id="padBookmarkMain">
+            <div id="padBookmarkList">
+            
+            </div>
+            <br/>
+            <div>
+                <input id="autoAddBookmarkCheckbox" type="checkbox"/>
+                <span id="addBookmarksAutomatically" data-l10n-id="ep_bookmark.addBookmarksAutomatically">Add bookmarks automatically</span>
+            </div>
+            <br/>
+            <div>
+                <input type="button" class="embedMediaButton" id="addPadBookmark" data-l10n-id="ep_bookmark.addPadToBookmarks" value="Add this pad to bookmarks">
+            </div>
         </div>
     <% e.end_block(); %>
 </div>


### PR DESCRIPTION
I have made a few changes to make the usage of localStorage more robust. There should be no JavaScript errors anymore in case localStorage is unavailable or disabled. Instead, the user will get a hint that his browser does not support the saving of bookmarks.
